### PR TITLE
65 bugfix ticket13 get all packingitems

### DIFF
--- a/frontend/src/components/packingListDetails/EditPackingList.tsx
+++ b/frontend/src/components/packingListDetails/EditPackingList.tsx
@@ -20,7 +20,8 @@ export default function EditPackingList({id, detailedPackingList, setShowsDetail
         event.preventDefault()
         const editedPackingList: Omit<PackingList, "id"> = {
             destination: newDestination,
-            dateOfArrival: newDateOfArrival
+            dateOfArrival: newDateOfArrival,
+            packingItemList: detailedPackingList.packingItemList
         }
         updateListAndGetNewDetails(id, editedPackingList)
         setShowsDetails(false)

--- a/frontend/src/hooks/useDetailedPackingList.tsx
+++ b/frontend/src/hooks/useDetailedPackingList.tsx
@@ -13,15 +13,5 @@ export default function useDetailedPackingList() {
             .catch((error) => toast.error(error))
     }
 
-    const getUpdatedDetails = (idOfUpdatedList: string, editedPackingList: Omit<PackingList, "id">) => {
-        const updatedPackingList: PackingList = {
-            id: idOfUpdatedList,
-            destination : editedPackingList.destination,
-            dateOfArrival : editedPackingList.dateOfArrival,
-            packingItemList : editedPackingList.packingItemList
-        }
-        setDetailedPackingList(updatedPackingList)
-    }
-
-    return {detailedPackingList, getDetailedPackingListById, getUpdatedDetails}
+    return {detailedPackingList, getDetailedPackingListById, setDetailedPackingList}
 }

--- a/frontend/src/hooks/useDetailedPackingList.tsx
+++ b/frontend/src/hooks/useDetailedPackingList.tsx
@@ -17,7 +17,8 @@ export default function useDetailedPackingList() {
         const updatedPackingList: PackingList = {
             id: idOfUpdatedList,
             destination : editedPackingList.destination,
-            dateOfArrival : editedPackingList.dateOfArrival
+            dateOfArrival : editedPackingList.dateOfArrival,
+            packingItemList : editedPackingList.packingItemList
         }
         setDetailedPackingList(updatedPackingList)
     }

--- a/frontend/src/pages/PackingListDetailsPage.tsx
+++ b/frontend/src/pages/PackingListDetailsPage.tsx
@@ -8,18 +8,18 @@ import PackingListEditMode from "../components/packingListDetails/PackingListEdi
 import PackingListDetailMode from "../components/packingListDetails/PackingListDetailMode";
 
 type PackingListDetailsPageProps = {
-    updatePackingList: (id: string, editedPackingList: Omit<PackingList, "id">) => void
+    updatePackingList: (id: string, editedPackingList: Omit<PackingList, "id">) => Promise<PackingList | void>
 }
 
 export default function PackingListDetailsPage({updatePackingList}: PackingListDetailsPageProps) {
 
-    const {detailedPackingList, getDetailedPackingListById, getUpdatedDetails} = useDetailedPackingList()
+    const {detailedPackingList, getDetailedPackingListById, setDetailedPackingList} = useDetailedPackingList()
     const {id} = useParams()
     const [showsDetails, setShowsDetails] = useState<boolean>(false);
 
     const updateListAndGetNewDetails = (idOfEditedList: string, editedPackingList: Omit<PackingList, "id">) => {
         updatePackingList(idOfEditedList, editedPackingList)
-        getUpdatedDetails(idOfEditedList, editedPackingList)
+            .then((response) => response && setDetailedPackingList(response))
     }
 
     useEffect(() => {


### PR DESCRIPTION
fixed bug from Ticket #13: while editing the PackingList, the packingItems are not displayed. 
modified the update-call to use response to set state of detailedPackingList.